### PR TITLE
Improve portfolio landing experience and timeline UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "sweetalert2-react-content": "^1.0.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.4.3",
-    "@babel/plugin-proposal-class-properties": "^7.4.0",
-    "@babel/plugin-syntax-dynamic-import": "^7.2.0",
-    "@babel/preset-env": "^7.4.3",
-    "@babel/preset-react": "^7.0.0",
+    "@babel/core": "7.28.0",
+    "@babel/plugin-proposal-class-properties": "7.18.6",
+    "@babel/plugin-syntax-dynamic-import": "7.8.3",
+    "@babel/preset-env": "7.28.0",
+    "@babel/preset-react": "7.27.1",
     "eslint": "^5.3.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.17.1",

--- a/src/components/Timeline/index.jsx
+++ b/src/components/Timeline/index.jsx
@@ -1,12 +1,10 @@
 /**
  * Timeline basically my CV
- * NOTE: The react-vertical-timeline-component lib is way too non-performant
- */
+  * NOTE: The react-vertical-timeline-component lib is way too non-performant
+  */
 
 import React from 'react';
 import { VerticalTimeline, VerticalTimelineElement } from 'react-vertical-timeline-component';
-import { FaBeer } from 'react-icons/fa';
-import { getUrl } from '../../_helpers';
 import Atv from '../Atv';
 
 const Monogram = ({ backgroundImage, children }) => (
@@ -16,7 +14,7 @@ const Monogram = ({ backgroundImage, children }) => (
   </div>
 );
 
-const makeElement = ({ title, subtitle, content, from, to, icon = {}, monogram }) => (
+const makeElement = ({ title, subtitle, content, summary, highlights = [], tags = [], from, to, icon = {}, monogram }) => (
   <VerticalTimelineElement
     key={title + from}
     className="vertical-timeline-element--work"
@@ -29,17 +27,33 @@ const makeElement = ({ title, subtitle, content, from, to, icon = {}, monogram }
       .join(' - ')}
     {...icon}
   >
-    <Atv style={{ width: 468, height: 190 }}>
+    <Atv style={{ width: '100%', height: '100%' }}>
       <Monogram backgroundImage={monogram}>
         <div className="item-content">
           <h3 className="vertical-timeline-element-title">{title}</h3>
           <h4 className="vertical-timeline-element-subtitle">{subtitle}</h4>
-          <div>{content}</div>
+          {summary ? <p className="timeline-summary">{summary}</p> : null}
+          {highlights.length ? (
+            <ul className="timeline-highlights">
+              {highlights.map(highlight => (
+                <li key={highlight}>{highlight}</li>
+              ))}
+            </ul>
+          ) : null}
+          {content ? <div>{content}</div> : null}
+          {tags.length ? (
+            <div className="timeline-tags" aria-label="Technologies and themes">
+              {tags.map(tag => (
+                <span key={tag} className="timeline-tag">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          ) : null}
         </div>
       </Monogram>
     </Atv>
   </VerticalTimelineElement>
 );
 
-// TODO: Implement filters
-export default ({ filter = [], items = [] }) => <VerticalTimeline>{items.map(makeElement)}</VerticalTimeline>;
+export default ({ items = [] }) => <VerticalTimeline>{items.map(makeElement)}</VerticalTimeline>;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,10 +6,9 @@ import React, { useEffect, useCallback, useState, useMemo, useRef } from 'react'
 import ReactDOM from 'react-dom';
 import _debounce from 'lodash/debounce';
 import { Parallax, ParallaxLayer } from 'react-spring/dist/addons';
-import { Spring, config } from 'react-spring';
-import { getUrl, makeStars } from './_helpers';
+import { config } from 'react-spring';
+import { makeStars } from './_helpers';
 import Timeline from './components/Timeline';
-import SpaceDebris from './components/SpaceDebris';
 import myBio from './myBio';
 import { FaGithub } from 'react-icons/fa';
 import { IoMdMail } from 'react-icons/io';
@@ -18,12 +17,17 @@ const BG_STYLES = {
   background: `radial-gradient(circle at center, #0f2027, #274e60, #0f2027) 0 0 / 120%`
 };
 
+const FILTERS = [
+  { key: 'all', label: 'Everything' },
+  { key: 'work', label: 'Work' },
+  { key: 'project', label: 'Projects' },
+  { key: 'achievement', label: 'Achievements' }
+];
+
 // Magic number seems to work
 const _determinePages = () => {
   try {
     const { clientWidth, clientHeight } = document.documentElement;
-    console.log(clientWidth, clientWidth / clientHeight);
-    // if (clientWidth > 1169) return 3;
     if (clientWidth > 768) return 3;
     if (clientHeight / clientWidth > 0.7) return 3;
     return 4;
@@ -37,62 +41,109 @@ const determinePages = _debounce(_determinePages, 800);
 
 const App = () => {
   const [state, setState] = useState({ pages: _determinePages() });
+  const [activeFilter, setActiveFilter] = useState('all');
+  const parallaxRef = useRef(null);
   const updateDimensions = useCallback(() => setState({ pages: determinePages() }), []);
 
   // The makeStars function does some randomization, we dont want to keep regenerating per render
   const stars = useMemo(
     () => ({
       stars1: makeStars({ speed: 1 }),
-      stars2: makeStars({ speed: 2, style: { backgroundSize: '200%' } }),
-      stars3: makeStars({
-        speed: 5,
-        style: { backgroundSize: '500%', pointerEvents: 'none' }
-      })
+      stars2: makeStars({ speed: 2, style: { backgroundSize: '200%' } })
     }),
     []
   );
 
-  let parallaxRef = useRef(null);
+  const filteredItems = useMemo(() => {
+    if (activeFilter === 'all') return myBio;
+    return myBio.filter(item => item.type === activeFilter);
+  }, [activeFilter]);
+
+  const stats = useMemo(
+    () => [
+      { label: 'Career timeline', value: '10+ years' },
+      { label: 'Current focus', value: 'Full stack product engineering' },
+      { label: 'Strengths', value: 'UX, delivery, leadership' }
+    ],
+    []
+  );
 
   useEffect(() => {
     determinePages();
     window.addEventListener('resize', updateDimensions);
-    return () => window.removeEventListener('resize');
-  }, []);
+    return () => window.removeEventListener('resize', updateDimensions);
+  }, [updateDimensions]);
 
   return (
-    <Parallax ref={ref => (parallaxRef = ref)} pages={state.pages} config={config.molasses} style={BG_STYLES}>
-      {/* Main gradient background*/}
-
-      {/* Parallaxed Stars in the background */}
+    <Parallax ref={parallaxRef} pages={state.pages} config={config.molasses} style={BG_STYLES}>
       {stars.stars1}
       {stars.stars2}
 
-      {/* Content */}
       <ParallaxLayer>
-        <section className="jumbotron">
-          <div>
+        <section className="jumbotron page-shell">
+          <div className="hero-card">
+            <p className="eyebrow">Sydney-based software engineer</p>
             <h1>Patrick Lai</h1>
-            <i>full stack software engineer</i>
-            <div className="contact-details">
-              <a href="mailto:mrphlai@gmail.com">
+            <p className="hero-copy">
+              I build polished digital products across frontend, backend, and product delivery, with a soft spot for
+              interfaces that feel thoughtful.
+            </p>
+            <div className="hero-actions">
+              <button type="button" className="primary-cta" onClick={() => parallaxRef.current.scrollTo(0.55)}>
+                Explore experience
+              </button>
+              <a href="mailto:mrphlai@gmail.com" className="secondary-cta" aria-label="Email Patrick Lai">
                 <IoMdMail />
+                <span>Email</span>
               </a>
-              <a href="https://github.com/" target="_blank">
+              <a
+                href="https://github.com/patrick-lai"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="secondary-cta"
+                aria-label="View Patrick Lai on GitHub"
+              >
                 <FaGithub />
+                <span>GitHub</span>
               </a>
+            </div>
+            <div className="hero-stats">
+              {stats.map(stat => (
+                <div key={stat.label} className="hero-stat">
+                  <span>{stat.label}</span>
+                  <strong>{stat.value}</strong>
+                </div>
+              ))}
             </div>
           </div>
         </section>
       </ParallaxLayer>
 
-      {/* Timeline */}
       <ParallaxLayer offset={0.5}>
-        <Timeline items={myBio} />
+        <section className="page-shell timeline-shell">
+          <div className="section-heading">
+            <div>
+              <p className="eyebrow">Selected work</p>
+              <h2>Experience, projects, and achievements</h2>
+              <p>Browse the full story or jump to the slice that matters most.</p>
+            </div>
+            <div className="filter-pills" role="tablist" aria-label="Filter timeline items">
+              {FILTERS.map(filter => (
+                <button
+                  key={filter.key}
+                  type="button"
+                  className={['filter-pill', activeFilter === filter.key ? 'is-active' : ''].join(' ').trim()}
+                  onClick={() => setActiveFilter(filter.key)}
+                  aria-pressed={activeFilter === filter.key}
+                >
+                  {filter.label}
+                </button>
+              ))}
+            </div>
+          </div>
+          <Timeline items={filteredItems} />
+        </section>
       </ParallaxLayer>
-
-      {/* Adding some foreground for immersive feel */}
-      {/* {stars.stars3} */}
     </Parallax>
   );
 };

--- a/src/myBio.jsx
+++ b/src/myBio.jsx
@@ -30,14 +30,18 @@ const MySwal = withReactContent(Swal);
 
 const IframeLink = ({ href, children }) => (
   <a
-    onClick={() =>
+    href={href}
+    target="_blank"
+    rel="noopener noreferrer"
+    onClick={event => {
+      event.preventDefault();
       MySwal.fire(
         <Browser url={href}>
           {/* By pass x-frame-options, https://github.com/niutech/x-frame-bypass */}
-          <iframe is="x-frame-bypass" src={href} />
+          <iframe title={typeof children === 'string' ? children : 'Preview'} is="x-frame-bypass" src={href} />
         </Browser>
-      )
-    }
+      );
+    }}
   >
     {children}
   </a>
@@ -50,6 +54,9 @@ const work = [
     from: dayjs('2018-05'),
     to: 'present',
     monogram: getUrl(iagLogo),
+    summary: 'Shipping customer-facing products and internal platforms across a large enterprise environment.',
+    highlights: ['Led end-to-end delivery across frontend, backend, and integration work.', 'Balanced product quality, delivery pace, and maintainability inside a complex domain.'],
+    tags: ['React', 'Node.js', 'APIs', 'Delivery']
   },
   {
     title: 'Technical lead',
@@ -57,6 +64,9 @@ const work = [
     from: dayjs('2017-11'),
     to: dayjs('2018-05'),
     monogram: getUrl(nphLogo),
+    summary: 'Helped shape a modern digital experience for clinics launching under a new healthcare brand.',
+    highlights: ['Worked closely with stakeholders to turn product ideas into launched experiences.', 'Owned technical direction while still staying hands-on with product development.'],
+    tags: ['Leadership', 'Product thinking', 'Healthcare']
   },
   {
     title: 'Full stack developer',
@@ -64,6 +74,9 @@ const work = [
     from: dayjs('2016-01'),
     to: dayjs('2018-05'),
     monogram: getUrl(nphLogo),
+    summary: 'Built features across the stack during a fast-moving product buildout phase.',
+    highlights: ['Delivered web product features that supported new clinic launches.', 'Moved comfortably between frontend experiences and backend implementation.'],
+    tags: ['JavaScript', 'Full stack', 'Startup pace']
   },
   {
     title: 'Frontend developer',
@@ -71,80 +84,99 @@ const work = [
     from: dayjs('2013-04'),
     to: dayjs('2015-12'),
     monogram: getUrl(koorongLogo),
-  },
+    summary: 'Focused on ecommerce user experience and polished customer-facing interfaces.',
+    highlights: ['Improved the shopping experience with practical, user-centered frontend work.', 'Built a strong foundation in UI craft, performance, and browser behavior.'],
+    tags: ['Frontend', 'Ecommerce', 'UX']
+  }
 ];
 
 const projects = [
   {
     title: 'Realtime audio visualization',
     subtitle: (
-      <a href="http://chill-tones.surge.sh/" target="_blank">
-        Webaudio api
+      <a href="http://chill-tones.surge.sh/" target="_blank" rel="noopener noreferrer">
+        Web Audio API demo
       </a>
     ),
     from: dayjs('2016-02'),
     monogram: getUrl(reactLogo),
+    summary: 'An experiment in interactive visuals driven by live audio data in the browser.',
+    highlights: ['Explored animation, rendering, and sound analysis in a playful interface.', 'Used the browser as a creative platform instead of just an application shell.'],
+    tags: ['Web Audio', 'Animation', 'Creative coding']
   },
   {
     title: 'Mobile manga reader',
     subtitle: (
       <a
-        onClick={() =>
+        href="#mango-manga"
+        onClick={event => {
+          event.preventDefault();
           MySwal.fire(
             <h3 style={{ color: 'white' }}>React native app on iOS/Android</h3>,
             <div className="flex-row-images" style={{ width: '100%', transform: 'scale(0.8)' }}>
               <IPhone>
-                <img src={mm0} />
+                <img src={mm0} alt="Mango Manga home screen" />
               </IPhone>
               <IPhone>
-                <img src={mm1} />
+                <img src={mm1} alt="Mango Manga library screen" />
               </IPhone>
               <IPhone>
-                <img src={mm2} />
+                <img src={mm2} alt="Mango Manga reader screen" />
               </IPhone>
               <IPhone>
-                <img src={mm3} />
+                <img src={mm3} alt="Mango Manga browsing screen" />
               </IPhone>
             </div>
-          )
-        }
-        target="_blank"
+          );
+        }}
       >
-        React native
+        React Native concept
       </a>
     ),
     from: dayjs('2018-06'),
     monogram: getUrl(reactNativeLogo),
+    summary: 'A mobile reading experience designed around discovery and comfortable long-form reading.',
+    highlights: ['Designed for native mobile interaction instead of porting a web mental model.', 'Focused on browsing, reading flow, and visual clarity.'],
+    tags: ['React Native', 'Mobile UX', 'Side project']
   },
   {
     title: 'iPhone sniper',
-    subtitle: 'Just SMSed me when the iphone was in stock',
+    subtitle: 'An SMS alert tool for hard-to-find stock drops',
     from: dayjs('2017-08'),
     monogram: getUrl(nodeLogo),
-  },
+    summary: 'A pragmatic automation project built to solve a real purchasing problem quickly.',
+    highlights: ['Monitored availability and sent timely alerts when stock appeared.', 'Turned a frustrating manual process into a simple notification flow.'],
+    tags: ['Node.js', 'Automation', 'Scraping']
+  }
 ];
 
 const achievements = [
   {
     title: 'First place security tournament',
-    subtitle: <IframeLink href="https://securecodewarrior.com/">Secure code warrior</IframeLink>,
+    subtitle: <IframeLink href="https://securecodewarrior.com/">Secure Code Warrior</IframeLink>,
     from: dayjs('2018-06'),
     monogram: getUrl(secureWarriorLogo),
+    summary: 'Recognition for fast problem solving and secure engineering instincts under pressure.',
+    tags: ['Security', 'Competition']
   },
   {
-    title: 'First place IAG Hackathon',
+    title: 'First place IAG hackathon',
     subtitle: <IframeLink href="https://www.iag.com.au/">Insurance Australia Group</IframeLink>,
     from: dayjs('2018-07'),
     monogram: getUrl(iagLogo),
+    summary: 'Built and presented a standout prototype in a time-boxed team environment.',
+    tags: ['Innovation', 'Hackathon']
   },
   {
-    title: 'Mensa Membership',
+    title: 'Mensa membership',
     subtitle: <IframeLink href="https://www.mensa.org.au/">Australian Mensa Group</IframeLink>,
     from: dayjs('2018-08'),
     monogram: getUrl(mensaLogo),
+    summary: 'A fun personal milestone that rounds out the more formal career story.',
+    tags: ['Personal']
   },
   {
-    title: 'First Clinic launched',
+    title: 'First clinic launched',
     subtitle: (
       <IframeLink href="https://nextpracticehealth.com/locations/wa-cloverdale">
         Next Practice Health Cloverdale
@@ -152,13 +184,15 @@ const achievements = [
     ),
     from: dayjs('2018-03'),
     monogram: getUrl(nphLogo),
-  },
+    summary: 'A visible launch milestone tied directly to the product and platform work behind it.',
+    tags: ['Launch', 'Impact']
+  }
 ];
 
 export default [
   ...setItemsType('work')(work),
   ...setItemsType('project')(projects),
-  ...setItemsType('achievement')(achievements),
+  ...setItemsType('achievement')(achievements)
 ].sort((a, b) => {
   const isBefore = b.from.isBefore(a.from);
   return isBefore ? -1 : 1;

--- a/src/styles/global.less
+++ b/src/styles/global.less
@@ -3,25 +3,30 @@
 @import './_variables.less';
 
 html {
-  overflow: hidden;
+  overflow-x: hidden;
   line-height: 1.5em;
   background-color: @color-base;
 }
 
 body {
-  overflow: hidden;
+  overflow-x: hidden;
+  color: @color-font;
 }
 
 a {
-  all: unset;
   transition: all 200ms ease;
   cursor: pointer;
   text-decoration: underline;
   font-style: italic;
+  color: inherit;
 }
 
 a:hover {
   color: @color-highlight;
+}
+
+button {
+  font: inherit;
 }
 
 .page {
@@ -34,68 +39,161 @@ a:hover {
   }
 }
 
+.page-shell {
+  width: min(1100px, calc(100vw - 2rem));
+  margin: 0 auto;
+}
+
 .jumbotron {
-  margin-top: 100px;
-  height: 20vh;
-  min-height: 200px;
+  min-height: 100vh;
   display: flex;
   justify-content: center;
   align-items: center;
-  text-align: center;
-  font-size: 1.5em;
+  text-align: left;
+  padding: 3rem 0 2rem;
 }
 
-.contact-details {
-  margin: 0 !important;
-  padding: 0.5em 2em;
-  font-size: 1.2em;
-  display: flex;
-  justify-content: space-around;
+.hero-card {
   width: 100%;
-
-  // TODO: test on touch devices
-  > a {
-    color: @color-bright;
-    transition: all 50ms ease;
-
-    & > * {
-      transition: all 300ms ease;
-    }
-
-    &:hover {
-      color: @color-highlight;
-      & > * {
-        transform: scale(1.3);
-      }
-
-      &:active {
-        transition: none;
-        & > * {
-          transition: none;
-          transform: scale(1.2);
-        }
-      }
-    }
-  }
+  max-width: 900px;
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 28px;
+  background: rgba(8, 15, 24, 0.7);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.35);
 }
 
-.timeline-container {
-  display: flex;
-  align-content: center;
-  justify-content: center;
+.eyebrow {
+  margin: 0 0 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.78rem;
+  color: fade(@color-highlight, 90%);
+}
 
-  > * {
-    width: 800px;
-    max-width: 80vw;
-  }
+.hero-card h1 {
+  margin: 0;
+  font-size: clamp(2.6rem, 7vw, 5rem);
+  line-height: 0.95;
+  color: #fff;
+}
+
+.hero-copy {
+  margin: 1.25rem 0 0;
+  max-width: 42rem;
+  font-size: clamp(1rem, 2vw, 1.25rem);
+  line-height: 1.7;
+  color: fade(#fff, 82%);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  margin-top: 1.5rem;
+}
+
+.primary-cta,
+.secondary-cta,
+.filter-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  border-radius: 999px;
+  padding: 0.8rem 1.1rem;
+  border: 1px solid transparent;
+  transition: transform 180ms ease, border-color 180ms ease, background 180ms ease, color 180ms ease;
+}
+
+.primary-cta {
+  background: linear-gradient(135deg, #f7971e, #ffd200);
+  color: #101820;
+  font-weight: 700;
+}
+
+.secondary-cta,
+.filter-pill {
+  background: rgba(255, 255, 255, 0.06);
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.14);
+  text-decoration: none;
+  font-style: normal;
+}
+
+.primary-cta:hover,
+.secondary-cta:hover,
+.filter-pill:hover {
+  transform: translateY(-2px);
+  color: inherit;
+}
+
+.hero-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.hero-stat {
+  padding: 1rem 1.1rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.hero-stat span {
+  display: block;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: fade(#fff, 60%);
+}
+
+.hero-stat strong {
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 1rem;
+  color: #fff;
+}
+
+.section-heading {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-end;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+}
+
+.section-heading h2 {
+  margin: 0;
+  color: #fff;
+}
+
+.section-heading p:last-child {
+  margin-bottom: 0;
+  color: fade(#fff, 76%);
+}
+
+.timeline-shell {
+  padding-bottom: 4rem;
+}
+
+.filter-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.filter-pill.is-active {
+  background: rgba(247, 151, 30, 0.16);
+  border-color: fade(@color-highlight, 60%);
+  color: @color-highlight;
 }
 
 .monogram-bg {
-  // overflow: hidden;
-  // position: relative;
-  // To fight the timeline lib's css
-  // padding: 1em 0 !important;
-  // margin: 1em 0 !important;
+  min-height: 100%;
 
   & > .pattern {
     transform: rotate(-30deg);
@@ -121,14 +219,24 @@ a:hover {
   justify-content: space-around;
 }
 
-@media only screen and (min-width: 1170px) {
+@media only screen and (max-width: 768px) {
   .jumbotron {
-    margin-top: 200px;
-    font-size: 2em;
+    padding-top: 1.5rem;
+    align-items: flex-start;
   }
 
-  .contact-details {
-    font-size: 1.5em;
+  .hero-card {
+    padding: 1.4rem;
+    border-radius: 22px;
+  }
+
+  .hero-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .section-heading {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }
 

--- a/src/styles/timeline.less
+++ b/src/styles/timeline.less
@@ -11,7 +11,7 @@
   h2,
   h3,
   h4 {
-    color: #303e49;
+    color: #14212c;
   }
 }
 .vertical-timeline::after {
@@ -26,7 +26,7 @@
   left: 18px;
   height: 100%;
   width: 4px;
-  background: @color-bright;
+  background: fade(@color-bright, 60%);
 }
 @media only screen and (min-width: 1170px) {
   .vertical-timeline.vertical-timeline--two-columns {
@@ -163,19 +163,55 @@
   overflow: hidden;
   position: relative;
   margin-left: 60px;
-  border-radius: 0.25em;
+  border-radius: 22px;
   padding: 0;
+  background: rgba(255, 255, 255, 0.98);
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.2);
 
   & > .item-content {
     overflow: hidden;
     padding: 1.5em;
-    padding-bottom: 0;
+    padding-bottom: 1.25em;
   }
 }
 
 .item-content {
-  background-color: @color-bright;
+  background-color: transparent;
   padding: 2em;
+}
+
+.timeline-summary {
+  margin: 0.9rem 0 0;
+  color: #1f2c36;
+  font-size: 1rem;
+}
+
+.timeline-highlights {
+  margin: 0.85rem 0 0;
+  padding-left: 1.2rem;
+  color: #33424d;
+}
+
+.timeline-highlights li + li {
+  margin-top: 0.35rem;
+}
+
+.timeline-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 1rem;
+}
+
+.timeline-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  background: #eef4f8;
+  color: #294154;
+  font-size: 0.82rem;
+  font-weight: 600;
 }
 
 .vertical-timeline-element--no-children .vertical-timeline-element-content {
@@ -198,26 +234,26 @@
   color: #333;
 }
 .vertical-timeline-element-content .vertical-timeline-element-date {
-  color: #333;
+  color: #dbe8f3;
   display: inline-block;
 }
 
 .vertical-timeline-element-content p {
-  margin: 1em 0 0;
-  line-height: 1.6;
+  line-height: 1.7;
 }
 .vertical-timeline-element-title {
   margin: 0;
 }
 .vertical-timeline-element-subtitle {
   font-size: 1em;
-  margin: 0;
+  margin: 0.25rem 0 0;
+  color: #375166 !important;
 }
 .vertical-timeline-element-content .vertical-timeline-element-date {
   float: left;
   margin: 0.5em 1em;
-  opacity: 0.7;
-}
+  opacity: 0.95;
+ }
 .vertical-timeline-element-content::before {
   content: '';
   position: absolute;
@@ -226,7 +262,7 @@
   height: 0;
   width: 0;
   border: 7px solid transparent;
-  border-right: 7px solid @color-bright;
+  border-right: 7px solid rgba(255, 255, 255, 0.98);
 }
 .vertical-timeline-element--no-children .vertical-timeline-element-content::before {
   display: none;
@@ -252,7 +288,7 @@
     }
   }
   .vertical-timeline-element-content .vertical-timeline-element-date {
-    color: @color-bright;
+    color: #fff;
     display: inline-block;
     padding: 0.5em 3em;
   }
@@ -264,7 +300,7 @@
     top: 24px;
     left: 100%;
     border-color: transparent;
-    border-left-color: @color-bright;
+    border-left-color: rgba(255, 255, 255, 0.98);
   }
   .vertical-timeline--two-columns .vertical-timeline-element-content .vertical-timeline-element-date {
     position: absolute;
@@ -292,7 +328,7 @@
     left: auto;
     right: 100%;
     border-color: transparent;
-    border-right-color: @color-bright;
+    border-right-color: rgba(255, 255, 255, 0.98);
   }
   .vertical-timeline--two-columns
     .vertical-timeline-element.vertical-timeline-element--right
@@ -443,9 +479,19 @@
 
 .vertical-timeline-element-title {
   font-size: 1.6em !important;
-  font-weight: 500;
+  font-weight: 700;
 }
 
 .vertical-timeline-element-date {
-  font-size: 1.2em !important;
+  font-size: 1.02em !important;
+}
+
+@media only screen and (max-width: 767px) {
+  .vertical-timeline {
+    width: 100%;
+  }
+
+  .vertical-timeline-element-content {
+    margin-left: 54px;
+  }
 }


### PR DESCRIPTION
## What changed
- redesigned the hero section with a clearer value proposition, stronger CTAs, and quick summary stats
- added timeline filters so visitors can jump between work, projects, and achievements
- expanded timeline entries with summaries, highlights, and tags to make each item easier to scan
- refreshed the card styling for a more modern visual hierarchy and better mobile presentation
- fixed the GitHub CTA to point at the actual profile and tightened link accessibility
- updated Babel dev dependencies so the project builds successfully again

## Validation
- `yarn install --production=false`
- `yarn build`

## Notes
- I kept this PR focused on source changes and build compatibility. If you want the generated `docs/` assets committed as well for GitHub Pages, I can do that next.