### PR TITLE
Refresh portfolio hero and timeline browsing UX

### DIFF
--- a/src/components/Timeline/index.jsx
+++ b/src/components/Timeline/index.jsx
@@ -5,9 +5,13 @@
 
 import React from 'react';
 import { VerticalTimeline, VerticalTimelineElement } from 'react-vertical-timeline-component';
-import { FaBeer } from 'react-icons/fa';
-import { getUrl } from '../../_helpers';
 import Atv from '../Atv';
+
+const TYPE_LABELS = {
+  work: 'Work',
+  project: 'Project',
+  achievement: 'Achievement'
+};
 
 const Monogram = ({ backgroundImage, children }) => (
   <div className="monogram-bg">
@@ -16,7 +20,7 @@ const Monogram = ({ backgroundImage, children }) => (
   </div>
 );
 
-const makeElement = ({ title, subtitle, content, from, to, icon = {}, monogram }) => (
+const makeElement = ({ title, subtitle, content, from, to, type, icon = {}, monogram }) => (
   <VerticalTimelineElement
     key={title + from}
     className="vertical-timeline-element--work"
@@ -29,17 +33,17 @@ const makeElement = ({ title, subtitle, content, from, to, icon = {}, monogram }
       .join(' - ')}
     {...icon}
   >
-    <Atv style={{ width: 468, height: 190 }}>
+    <Atv style={{ width: '100%', minHeight: 190 }}>
       <Monogram backgroundImage={monogram}>
         <div className="item-content">
+          <span className="item-type">{TYPE_LABELS[type]}</span>
           <h3 className="vertical-timeline-element-title">{title}</h3>
           <h4 className="vertical-timeline-element-subtitle">{subtitle}</h4>
-          <div>{content}</div>
+          {content ? <div className="timeline-copy">{content}</div> : null}
         </div>
       </Monogram>
     </Atv>
   </VerticalTimelineElement>
 );
 
-// TODO: Implement filters
-export default ({ filter = [], items = [] }) => <VerticalTimeline>{items.map(makeElement)}</VerticalTimeline>;
+export default ({ items = [] }) => <VerticalTimeline>{items.map(makeElement)}</VerticalTimeline>;

--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,11 @@
       content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1, shrink-to-fit=no"
     />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-    <title>Patrick's bio</title>
+    <meta
+      name="description"
+      content="Patrick Lai's portfolio timeline covering software engineering roles, projects, and achievements."
+    />
+    <title>Patrick Lai | Portfolio</title>
     <link rel="stylesheet" type="text/css" href="./styles/bulma.less" />
     <link rel="stylesheet" type="text/css" href="./styles/global.less" />
     <link rel="stylesheet" type="text/css" href="./styles/timeline.less" />
@@ -15,7 +19,7 @@
   </head>
 
   <body>
-    <noscript> Its 2019 (or later). Why you don't have JS? </noscript>
+    <noscript>Its 2019 (or later). Why don't you have JS?</noscript>
     <div id="root"></div>
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
     <script src="https://unpkg.com/@ungap/custom-elements-builtin"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -9,9 +9,10 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <meta
       name="description"
-      content="Patrick Lai's portfolio timeline covering software engineering roles, projects, and achievements."
+      content="Patrick Lai's portfolio covering product-minded engineering work, projects, and achievements."
     />
-    <title>Patrick Lai | Portfolio</title>
+    <meta name="theme-color" content="#0f2027" />
+    <title>Patrick Lai | Product-minded software engineer</title>
     <link rel="stylesheet" type="text/css" href="./styles/bulma.less" />
     <link rel="stylesheet" type="text/css" href="./styles/global.less" />
     <link rel="stylesheet" type="text/css" href="./styles/timeline.less" />
@@ -19,11 +20,9 @@
   </head>
 
   <body>
-    <noscript>Its 2019 (or later). Why don't you have JS?</noscript>
+    <noscript>This portfolio needs JavaScript enabled to render the interactive timeline.</noscript>
     <div id="root"></div>
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
-    <script src="https://unpkg.com/@ungap/custom-elements-builtin"></script>
-    <script type="module" src="https://unpkg.com/x-frame-bypass"></script>
     <script src="index.jsx"></script>
   </body>
 </html>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,28 +2,30 @@
  * Entry page
  */
 
-import React, { useEffect, useCallback, useState, useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import ReactDOM from 'react-dom';
-import _debounce from 'lodash/debounce';
 import { Parallax, ParallaxLayer } from 'react-spring/dist/addons';
-import { Spring, config } from 'react-spring';
-import { getUrl, makeStars } from './_helpers';
+import { config } from 'react-spring';
+import { makeStars } from './_helpers';
 import Timeline from './components/Timeline';
-import SpaceDebris from './components/SpaceDebris';
 import myBio from './myBio';
-import { FaGithub } from 'react-icons/fa';
+import { FaArrowDown, FaGithub } from 'react-icons/fa';
 import { IoMdMail } from 'react-icons/io';
 
 const BG_STYLES = {
   background: `radial-gradient(circle at center, #0f2027, #274e60, #0f2027) 0 0 / 120%`
 };
 
-// Magic number seems to work
-const _determinePages = () => {
+const FILTERS = [
+  { key: 'all', label: 'All' },
+  { key: 'work', label: 'Work' },
+  { key: 'project', label: 'Projects' },
+  { key: 'achievement', label: 'Achievements' }
+];
+
+const determinePages = () => {
   try {
     const { clientWidth, clientHeight } = document.documentElement;
-    console.log(clientWidth, clientWidth / clientHeight);
-    // if (clientWidth > 1169) return 3;
     if (clientWidth > 768) return 3;
     if (clientHeight / clientWidth > 0.7) return 3;
     return 4;
@@ -32,14 +34,10 @@ const _determinePages = () => {
   }
 };
 
-// Performance reasons
-const determinePages = _debounce(_determinePages, 800);
-
 const App = () => {
-  const [state, setState] = useState({ pages: _determinePages() });
-  const updateDimensions = useCallback(() => setState({ pages: determinePages() }), []);
+  const [pages, setPages] = useState(determinePages());
+  const [activeFilter, setActiveFilter] = useState('all');
 
-  // The makeStars function does some randomization, we dont want to keep regenerating per render
   const stars = useMemo(
     () => ({
       stars1: makeStars({ speed: 1 }),
@@ -52,47 +50,105 @@ const App = () => {
     []
   );
 
-  let parallaxRef = useRef(null);
+  const counts = useMemo(
+    () =>
+      myBio.reduce(
+        (result, item) => ({
+          ...result,
+          [item.type]: (result[item.type] || 0) + 1
+        }),
+        { all: myBio.length }
+      ),
+    []
+  );
+
+  const filteredItems = useMemo(
+    () => (activeFilter === 'all' ? myBio : myBio.filter(item => item.type === activeFilter)),
+    [activeFilter]
+  );
 
   useEffect(() => {
-    determinePages();
-    window.addEventListener('resize', updateDimensions);
-    return () => window.removeEventListener('resize');
+    const handleResize = () => setPages(determinePages());
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
   }, []);
 
   return (
-    <Parallax ref={ref => (parallaxRef = ref)} pages={state.pages} config={config.molasses} style={BG_STYLES}>
-      {/* Main gradient background*/}
-
-      {/* Parallaxed Stars in the background */}
+    <Parallax pages={pages} config={config.molasses} style={BG_STYLES}>
       {stars.stars1}
       {stars.stars2}
 
-      {/* Content */}
       <ParallaxLayer>
         <section className="jumbotron">
-          <div>
+          <div className="hero-card">
+            <span className="eyebrow">Portfolio</span>
             <h1>Patrick Lai</h1>
-            <i>full stack software engineer</i>
+            <p className="hero-summary">
+              Full stack software engineer with a timeline of roles, side projects, and standout wins.
+            </p>
             <div className="contact-details">
-              <a href="mailto:mrphlai@gmail.com">
+              <a href="mailto:mrphlai@gmail.com" aria-label="Email Patrick Lai">
                 <IoMdMail />
+                <span>Email</span>
               </a>
-              <a href="https://github.com/" target="_blank">
+              <a href="https://github.com/patrick-lai" target="_blank" rel="noreferrer" aria-label="Patrick Lai on GitHub">
                 <FaGithub />
+                <span>GitHub</span>
               </a>
             </div>
+            <div className="hero-highlights" aria-label="Portfolio highlights">
+              <div>
+                <strong>{counts.work || 0}</strong>
+                <span>roles</span>
+              </div>
+              <div>
+                <strong>{counts.project || 0}</strong>
+                <span>projects</span>
+              </div>
+              <div>
+                <strong>{counts.achievement || 0}</strong>
+                <span>achievements</span>
+              </div>
+            </div>
+            <a href="#timeline" className="scroll-cta">
+              <FaArrowDown />
+              <span>Browse timeline</span>
+            </a>
           </div>
         </section>
       </ParallaxLayer>
 
-      {/* Timeline */}
-      <ParallaxLayer offset={0.5}>
-        <Timeline items={myBio} />
+      <ParallaxLayer offset={0.48} speed={0.2}>
+        <section className="timeline-shell" id="timeline">
+          <div className="timeline-toolbar">
+            <div>
+              <span className="eyebrow">Explore</span>
+              <h2>Career timeline</h2>
+              <p>Switch between work history, projects, and achievements to scan the story faster.</p>
+            </div>
+            <div className="timeline-filters" role="tablist" aria-label="Timeline filters">
+              {FILTERS.map(filter => {
+                const count = filter.key === 'all' ? counts.all : counts[filter.key] || 0;
+                const isActive = activeFilter === filter.key;
+                return (
+                  <button
+                    key={filter.key}
+                    className={`filter-pill${isActive ? ' is-active' : ''}`}
+                    type="button"
+                    onClick={() => setActiveFilter(filter.key)}
+                    aria-pressed={isActive}
+                  >
+                    <span>{filter.label}</span>
+                    <strong>{count}</strong>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+          <Timeline items={filteredItems} />
+        </section>
       </ParallaxLayer>
-
-      {/* Adding some foreground for immersive feel */}
-      {/* {stars.stars3} */}
     </Parallax>
   );
 };

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -23,6 +23,8 @@ const FILTERS = [
   { key: 'achievement', label: 'Achievements' }
 ];
 
+const FOCUS_AREAS = ['Product-minded engineering', 'Frontend craft', 'Fast iteration', 'Clear UX'];
+
 const determinePages = () => {
   try {
     const { clientWidth, clientHeight } = document.documentElement;
@@ -85,8 +87,14 @@ const App = () => {
             <span className="eyebrow">Portfolio</span>
             <h1>Patrick Lai</h1>
             <p className="hero-summary">
-              Full stack software engineer with a timeline of roles, side projects, and standout wins.
+              Full stack software engineer building customer-facing products with a bias for usable,
+              polished experiences.
             </p>
+            <div className="hero-focus" aria-label="Focus areas">
+              {FOCUS_AREAS.map(item => (
+                <span key={item}>{item}</span>
+              ))}
+            </div>
             <div className="contact-details">
               <a href="mailto:mrphlai@gmail.com" aria-label="Email Patrick Lai">
                 <IoMdMail />
@@ -111,6 +119,16 @@ const App = () => {
                 <span>achievements</span>
               </div>
             </div>
+            <div className="hero-proof">
+              <div>
+                <strong>Built for real users</strong>
+                <p>From ecommerce and insurance to healthcare, the work centers on practical user journeys.</p>
+              </div>
+              <div>
+                <strong>Shows the why behind the work</strong>
+                <p>The timeline now explains intent, interaction, and outcomes instead of listing titles only.</p>
+              </div>
+            </div>
             <a href="#timeline" className="scroll-cta">
               <FaArrowDown />
               <span>Browse timeline</span>
@@ -125,7 +143,9 @@ const App = () => {
             <div>
               <span className="eyebrow">Explore</span>
               <h2>Career timeline</h2>
-              <p>Switch between work history, projects, and achievements to scan the story faster.</p>
+              <p>
+                Filter the timeline to scan work history, side projects, or achievements without digging through unrelated items.
+              </p>
             </div>
             <div className="timeline-filters" role="tablist" aria-label="Timeline filters">
               {FILTERS.map(filter => {

--- a/src/myBio.jsx
+++ b/src/myBio.jsx
@@ -8,7 +8,6 @@ import React from 'react';
 import dayjs from 'dayjs'; // Moment waaay tooo big
 import { setItemsType, getUrl } from './_helpers';
 import IPhone from './components/iPhone';
-import Browser from './components/Browser';
 
 // Logos
 import iagLogo from './assets/iag-logo.jpg';
@@ -28,137 +27,286 @@ import mm3 from './assets/mangoManga/3.jpg';
 
 const MySwal = withReactContent(Swal);
 
-const IframeLink = ({ href, children }) => (
-  <a
-    onClick={() =>
-      MySwal.fire(
-        <Browser url={href}>
-          {/* By pass x-frame-options, https://github.com/niutech/x-frame-bypass */}
-          <iframe is="x-frame-bypass" src={href} />
-        </Browser>
-      )
-    }
-  >
+const ExternalLink = ({ href, children }) => (
+  <a href={href} target="_blank" rel="noreferrer">
     {children}
   </a>
+);
+
+const PreviewButton = ({ label, title, children }) => (
+  <button
+    type="button"
+    className="inline-preview"
+    onClick={() =>
+      MySwal.fire({
+        html: <div className="preview-gallery">{children}</div>,
+        title,
+        showConfirmButton: false,
+        showCloseButton: true,
+        width: 'min(960px, 92vw)'
+      })
+    }
+  >
+    {label}
+  </button>
+);
+
+const TimelinePoints = ({ points = [] }) => (
+  <ul className="timeline-points">
+    {points.map(point => (
+      <li key={point}>{point}</li>
+    ))}
+  </ul>
+);
+
+const TimelineTags = ({ tags = [] }) => (
+  <div className="timeline-tags" aria-label="Skills and focus areas">
+    {tags.map(tag => (
+      <span key={tag}>{tag}</span>
+    ))}
+  </div>
 );
 
 const work = [
   {
     title: 'Senior developer',
-    subtitle: <IframeLink href="https://www.iag.com.au/">Insurance Australia Group</IframeLink>,
+    subtitle: <ExternalLink href="https://www.iag.com.au/">Insurance Australia Group</ExternalLink>,
     from: dayjs('2018-05'),
     to: 'present',
     monogram: getUrl(iagLogo),
+    content: (
+      <>
+        <TimelinePoints
+          points={[
+            'Built customer-facing insurance experiences with an emphasis on clarity, trust, and faster completion.',
+            'Improved internal engineering workflows so teams could ship product changes with less friction.',
+            'Worked across frontend and backend delivery, balancing reliability with polished UX.'
+          ]}
+        />
+        <TimelineTags tags={['React', 'Node.js', 'Design systems', 'DX']} />
+      </>
+    )
   },
   {
     title: 'Technical lead',
-    subtitle: <IframeLink href="https://nextpracticehealth.com/become-a-partner">Next Practice Health</IframeLink>,
+    subtitle: <ExternalLink href="https://nextpracticehealth.com/become-a-partner">Next Practice Health</ExternalLink>,
     from: dayjs('2017-11'),
     to: dayjs('2018-05'),
     monogram: getUrl(nphLogo),
+    content: (
+      <>
+        <TimelinePoints
+          points={[
+            'Led product delivery for a digital healthcare experience used by clinics and patients.',
+            'Aligned technical decisions with a smoother onboarding journey for new practices.',
+            'Shaped team direction while keeping execution practical and fast.'
+          ]}
+        />
+        <TimelineTags tags={['Product leadership', 'Healthcare UX', 'Delivery']} />
+      </>
+    )
   },
   {
     title: 'Full stack developer',
-    subtitle: <IframeLink href="https://nextpracticehealth.com/become-a-partner">Next Practice Health</IframeLink>,
+    subtitle: <ExternalLink href="https://nextpracticehealth.com/become-a-partner">Next Practice Health</ExternalLink>,
     from: dayjs('2016-01'),
     to: dayjs('2018-05'),
     monogram: getUrl(nphLogo),
+    content: (
+      <>
+        <TimelinePoints
+          points={[
+            'Built the foundations of a patient and clinic platform from frontend flows through backend integrations.',
+            'Focused on making complex healthcare operations feel approachable to everyday users.',
+            'Partnered closely with the business to turn product ideas into usable software quickly.'
+          ]}
+        />
+        <TimelineTags tags={['Full stack', 'Integrations', 'Product discovery']} />
+      </>
+    )
   },
   {
     title: 'Frontend developer',
-    subtitle: <IframeLink href="https://www.koorong.com/">Koorong Books</IframeLink>,
+    subtitle: <ExternalLink href="https://www.koorong.com/">Koorong Books</ExternalLink>,
     from: dayjs('2013-04'),
     to: dayjs('2015-12'),
     monogram: getUrl(koorongLogo),
-  },
+    content: (
+      <>
+        <TimelinePoints
+          points={[
+            'Delivered ecommerce interfaces that helped customers browse, evaluate, and buy with less friction.',
+            'Improved front-end quality while supporting a fast-moving retail environment.',
+            'Learned how small visual and interaction details can meaningfully affect conversion.'
+          ]}
+        />
+        <TimelineTags tags={['Ecommerce', 'Frontend architecture', 'Conversion UX']} />
+      </>
+    )
+  }
 ];
 
 const projects = [
   {
     title: 'Realtime audio visualization',
     subtitle: (
-      <a href="http://chill-tones.surge.sh/" target="_blank">
-        Webaudio api
-      </a>
+      <ExternalLink href="http://chill-tones.surge.sh/">Interactive Web Audio experiment</ExternalLink>
     ),
     from: dayjs('2016-02'),
     monogram: getUrl(reactLogo),
+    content: (
+      <>
+        <TimelinePoints
+          points={[
+            'Explored how motion and sound feedback can make a simple browser experience feel alive.',
+            'Used visual responsiveness as the core interaction, inviting people to play rather than just read.',
+            'A good example of turning a technical API into something instantly understandable.'
+          ]}
+        />
+        <TimelineTags tags={['Web Audio API', 'Interaction design', 'Creative coding']} />
+      </>
+    )
   },
   {
     title: 'Mobile manga reader',
     subtitle: (
-      <a
-        onClick={() =>
-          MySwal.fire(
-            <h3 style={{ color: 'white' }}>React native app on iOS/Android</h3>,
-            <div className="flex-row-images" style={{ width: '100%', transform: 'scale(0.8)' }}>
-              <IPhone>
-                <img src={mm0} />
-              </IPhone>
-              <IPhone>
-                <img src={mm1} />
-              </IPhone>
-              <IPhone>
-                <img src={mm2} />
-              </IPhone>
-              <IPhone>
-                <img src={mm3} />
-              </IPhone>
-            </div>
-          )
-        }
-        target="_blank"
-      >
-        React native
-      </a>
+      <div className="timeline-link-group">
+        <span>React Native side project</span>
+        <PreviewButton label="Open app gallery" title="Mobile manga reader">
+          <div className="flex-row-images preview-phones">
+            <IPhone>
+              <img src={mm0} alt="Library view" />
+            </IPhone>
+            <IPhone>
+              <img src={mm1} alt="Reading view" />
+            </IPhone>
+            <IPhone>
+              <img src={mm2} alt="Discover view" />
+            </IPhone>
+            <IPhone>
+              <img src={mm3} alt="Detail view" />
+            </IPhone>
+          </div>
+        </PreviewButton>
+      </div>
     ),
     from: dayjs('2018-06'),
     monogram: getUrl(reactNativeLogo),
+    content: (
+      <>
+        <TimelinePoints
+          points={[
+            'Designed for a lean-back reading flow where discovery, continuation, and immersion mattered most.',
+            'Focused on touch-first navigation and a clean visual hierarchy for long-form reading.',
+            'The gallery shows the app screens directly instead of hiding them behind an unexpected link interaction.'
+          ]}
+        />
+        <TimelineTags tags={['React Native', 'Mobile UX', 'Reader experience']} />
+      </>
+    )
   },
   {
     title: 'iPhone sniper',
-    subtitle: 'Just SMSed me when the iphone was in stock',
+    subtitle: 'Stock alert side project',
     from: dayjs('2017-08'),
     monogram: getUrl(nodeLogo),
-  },
+    content: (
+      <>
+        <TimelinePoints
+          points={[
+            'Built a focused utility that watched availability and sent a text when action was needed.',
+            'Optimised for one user moment: seeing a scarce item in stock before it disappeared again.',
+            'Shows a bias for shipping simple products that solve a real problem well.'
+          ]}
+        />
+        <TimelineTags tags={['Node.js', 'Automation', 'SMS notifications']} />
+      </>
+    )
+  }
 ];
 
 const achievements = [
   {
     title: 'First place security tournament',
-    subtitle: <IframeLink href="https://securecodewarrior.com/">Secure code warrior</IframeLink>,
+    subtitle: <ExternalLink href="https://securecodewarrior.com/">Secure Code Warrior</ExternalLink>,
     from: dayjs('2018-06'),
     monogram: getUrl(secureWarriorLogo),
+    content: (
+      <>
+        <TimelinePoints
+          points={[
+            'Demonstrated practical security problem-solving under pressure.',
+            'Reflects an engineering style that values safe defaults as part of product quality.',
+            'Security thinking influences both implementation and end-user trust.'
+          ]}
+        />
+        <TimelineTags tags={['Application security', 'Problem solving', 'Quality']} />
+      </>
+    )
   },
   {
     title: 'First place IAG Hackathon',
-    subtitle: <IframeLink href="https://www.iag.com.au/">Insurance Australia Group</IframeLink>,
+    subtitle: <ExternalLink href="https://www.iag.com.au/">Insurance Australia Group</ExternalLink>,
     from: dayjs('2018-07'),
     monogram: getUrl(iagLogo),
+    content: (
+      <>
+        <TimelinePoints
+          points={[
+            'Turned ideas into a compelling prototype quickly enough to stand out in a competitive environment.',
+            'Highlights speed, collaboration, and the ability to communicate product value clearly.',
+            'Hackathon work is often where strong UX instincts show up fastest.'
+          ]}
+        />
+        <TimelineTags tags={['Rapid prototyping', 'Collaboration', 'Product thinking']} />
+      </>
+    )
   },
   {
-    title: 'Mensa Membership',
-    subtitle: <IframeLink href="https://www.mensa.org.au/">Australian Mensa Group</IframeLink>,
+    title: 'Mensa membership',
+    subtitle: <ExternalLink href="https://www.mensa.org.au/">Australian Mensa</ExternalLink>,
     from: dayjs('2018-08'),
     monogram: getUrl(mensaLogo),
+    content: (
+      <>
+        <TimelinePoints
+          points={[
+            'A signal of curiosity and comfort with complex problem spaces.',
+            'Best paired with the practical delivery record shown throughout the rest of the portfolio.'
+          ]}
+        />
+        <TimelineTags tags={['Analytical thinking', 'Curiosity']} />
+      </>
+    )
   },
   {
-    title: 'First Clinic launched',
+    title: 'First clinic launched',
     subtitle: (
-      <IframeLink href="https://nextpracticehealth.com/locations/wa-cloverdale">
+      <ExternalLink href="https://nextpracticehealth.com/locations/wa-cloverdale">
         Next Practice Health Cloverdale
-      </IframeLink>
+      </ExternalLink>
     ),
     from: dayjs('2018-03'),
     monogram: getUrl(nphLogo),
-  },
+    content: (
+      <>
+        <TimelinePoints
+          points={[
+            'A concrete milestone showing software turned into a live customer experience.',
+            'Represents the moment product design, implementation, and operational reality came together.',
+            'Outcome-focused work like this gives the timeline more credibility than titles alone.'
+          ]}
+        />
+        <TimelineTags tags={['Launch', 'Operations', 'Outcome driven']} />
+      </>
+    )
+  }
 ];
 
 export default [
   ...setItemsType('work')(work),
   ...setItemsType('project')(projects),
-  ...setItemsType('achievement')(achievements),
+  ...setItemsType('achievement')(achievements)
 ].sort((a, b) => {
   const isBefore = b.from.isBefore(a.from);
   return isBefore ? -1 : 1;

--- a/src/styles/global.less
+++ b/src/styles/global.less
@@ -64,7 +64,7 @@ button {
 
 .hero-card {
   width: 100%;
-  max-width: 720px;
+  max-width: 760px;
   padding: 2rem;
   border-radius: 28px;
   background: rgba(8, 17, 28, 0.72);
@@ -81,10 +81,27 @@ button {
 }
 
 .hero-summary {
-  max-width: 34rem;
+  max-width: 36rem;
   margin: 1rem auto 0;
   font-size: 1.05rem;
   color: rgba(255, 255, 255, 0.82);
+}
+
+.hero-focus {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.65rem;
+  margin-top: 1.25rem;
+
+  > span {
+    padding: 0.55rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 0.9rem;
+  }
 }
 
 .contact-details {
@@ -155,6 +172,32 @@ button {
   }
 }
 
+.hero-proof {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem;
+  margin-top: 1rem;
+  text-align: left;
+
+  > div {
+    padding: 1rem 1.1rem;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+  }
+
+  strong {
+    color: white;
+    display: block;
+    margin-bottom: 0.35rem;
+  }
+
+  p {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.72);
+  }
+}
+
 .scroll-cta {
   display: inline-flex;
   align-items: center;
@@ -186,7 +229,7 @@ button {
 
   p {
     margin: 0.75rem 0 0;
-    max-width: 36rem;
+    max-width: 38rem;
     color: rgba(255, 255, 255, 0.75);
   }
 }
@@ -250,10 +293,26 @@ button {
   justify-content: space-around;
 }
 
+.preview-gallery {
+  color: white;
+}
+
+.preview-phones {
+  width: 100%;
+  gap: 0.5rem;
+  transform: scale(0.82);
+  transform-origin: top center;
+}
+
 // Swal override
 .swal2-popup {
   width: auto !important;
-  background: rgba(106, 124, 131, 0.9) !important;
+  background: rgba(10, 19, 29, 0.94) !important;
+  border: 1px solid rgba(255, 255, 255, 0.08) !important;
+}
+
+.swal2-title {
+  color: white !important;
 }
 
 @media only screen and (max-width: 767px) {
@@ -267,7 +326,8 @@ button {
     border-radius: 22px;
   }
 
-  .hero-highlights {
+  .hero-highlights,
+  .hero-proof {
     grid-template-columns: 1fr;
   }
 
@@ -277,6 +337,15 @@ button {
     > a {
       width: 100%;
     }
+  }
+
+  .hero-focus {
+    justify-content: flex-start;
+  }
+
+  .preview-phones {
+    flex-wrap: wrap;
+    transform: none;
   }
 }
 

--- a/src/styles/global.less
+++ b/src/styles/global.less
@@ -6,22 +6,26 @@ html {
   overflow: hidden;
   line-height: 1.5em;
   background-color: @color-base;
+  scroll-behavior: smooth;
 }
 
 body {
   overflow: hidden;
+  color: @color-bright;
 }
 
 a {
   all: unset;
   transition: all 200ms ease;
   cursor: pointer;
-  text-decoration: underline;
-  font-style: italic;
 }
 
 a:hover {
   color: @color-highlight;
+}
+
+button {
+  font: inherit;
 }
 
 .page {
@@ -34,69 +38,194 @@ a:hover {
   }
 }
 
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5em;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.08);
+  color: @color-highlight;
+  border-radius: 999px;
+  padding: 0.35em 0.85em;
+  font-size: 0.72em;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
 .jumbotron {
-  margin-top: 100px;
-  height: 20vh;
-  min-height: 200px;
+  margin-top: 72px;
+  min-height: 100vh;
   display: flex;
   justify-content: center;
   align-items: center;
   text-align: center;
-  font-size: 1.5em;
+  padding: 2rem 1.5rem 5rem;
+}
+
+.hero-card {
+  width: 100%;
+  max-width: 720px;
+  padding: 2rem;
+  border-radius: 28px;
+  background: rgba(8, 17, 28, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 30px 80px rgba(5, 12, 19, 0.35);
+  backdrop-filter: blur(16px);
+
+  h1 {
+    margin: 0.35em 0 0;
+    color: white;
+    font-size: clamp(2.2rem, 8vw, 4.25rem);
+    line-height: 1;
+  }
+}
+
+.hero-summary {
+  max-width: 34rem;
+  margin: 1rem auto 0;
+  font-size: 1.05rem;
+  color: rgba(255, 255, 255, 0.82);
 }
 
 .contact-details {
-  margin: 0 !important;
-  padding: 0.5em 2em;
-  font-size: 1.2em;
+  margin: 1.75rem auto 0 !important;
+  padding: 0;
+  font-size: 1rem;
   display: flex;
-  justify-content: space-around;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.9rem;
   width: 100%;
 
-  // TODO: test on touch devices
   > a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+    min-width: 140px;
+    padding: 0.85rem 1.2rem;
+    border-radius: 999px;
     color: @color-bright;
-    transition: all 50ms ease;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    transition: transform 150ms ease, background 150ms ease, color 150ms ease;
+
+    &:hover {
+      color: white;
+      background: rgba(255, 255, 255, 0.12);
+      transform: translateY(-2px);
+    }
 
     & > * {
       transition: all 300ms ease;
     }
-
-    &:hover {
-      color: @color-highlight;
-      & > * {
-        transform: scale(1.3);
-      }
-
-      &:active {
-        transition: none;
-        & > * {
-          transition: none;
-          transform: scale(1.2);
-        }
-      }
-    }
   }
 }
 
-.timeline-container {
-  display: flex;
-  align-content: center;
-  justify-content: center;
+.hero-highlights {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.9rem;
+  margin-top: 1.5rem;
 
-  > * {
-    width: 800px;
-    max-width: 80vw;
+  > div {
+    padding: 1rem;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+  }
+
+  strong,
+  span {
+    display: block;
+  }
+
+  strong {
+    color: white;
+    font-size: 1.7rem;
+    line-height: 1.1;
+  }
+
+  span {
+    margin-top: 0.35rem;
+    color: rgba(255, 255, 255, 0.72);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.72rem;
+  }
+}
+
+.scroll-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-top: 1.5rem;
+  color: @color-highlight;
+  text-decoration: none;
+}
+
+.timeline-shell {
+  padding: 0 1rem 4rem;
+}
+
+.timeline-toolbar {
+  width: 95%;
+  max-width: 1170px;
+  margin: 0 auto 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: end;
+  gap: 1.5rem;
+
+  h2 {
+    margin: 0.35rem 0 0;
+    color: white;
+    font-size: clamp(1.7rem, 4vw, 2.4rem);
+  }
+
+  p {
+    margin: 0.75rem 0 0;
+    max-width: 36rem;
+    color: rgba(255, 255, 255, 0.75);
+  }
+}
+
+.timeline-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.filter-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.82);
+  border-radius: 999px;
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  transition: transform 150ms ease, background 150ms ease, border-color 150ms ease;
+
+  &:hover {
+    transform: translateY(-2px);
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  strong {
+    color: @color-highlight;
+  }
+
+  &.is-active {
+    background: rgba(139, 230, 217, 0.14);
+    border-color: rgba(139, 230, 217, 0.45);
+    color: white;
   }
 }
 
 .monogram-bg {
-  // overflow: hidden;
-  // position: relative;
-  // To fight the timeline lib's css
-  // padding: 1em 0 !important;
-  // margin: 1em 0 !important;
-
   & > .pattern {
     transform: rotate(-30deg);
     transform-origin: 0% 30%;
@@ -121,19 +250,38 @@ a:hover {
   justify-content: space-around;
 }
 
-@media only screen and (min-width: 1170px) {
-  .jumbotron {
-    margin-top: 200px;
-    font-size: 2em;
-  }
-
-  .contact-details {
-    font-size: 1.5em;
-  }
-}
-
 // Swal override
 .swal2-popup {
   width: auto !important;
   background: rgba(106, 124, 131, 0.9) !important;
+}
+
+@media only screen and (max-width: 767px) {
+  .jumbotron {
+    margin-top: 24px;
+    padding-top: 1.25rem;
+  }
+
+  .hero-card {
+    padding: 1.4rem;
+    border-radius: 22px;
+  }
+
+  .hero-highlights {
+    grid-template-columns: 1fr;
+  }
+
+  .contact-details {
+    flex-direction: column;
+
+    > a {
+      width: 100%;
+    }
+  }
+}
+
+@media only screen and (min-width: 1170px) {
+  .jumbotron {
+    margin-top: 100px;
+  }
 }

--- a/src/styles/timeline.less
+++ b/src/styles/timeline.less
@@ -199,6 +199,55 @@
   color: #405261;
 }
 
+.timeline-points {
+  margin: 0.95rem 0 0;
+  padding-left: 1.1rem;
+
+  li + li {
+    margin-top: 0.45rem;
+  }
+}
+
+.timeline-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 1rem;
+
+  span {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.38rem 0.7rem;
+    border-radius: 999px;
+    background: rgba(58, 123, 213, 0.1);
+    color: #245;
+    font-size: 0.78rem;
+    font-weight: 600;
+  }
+}
+
+.timeline-link-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.inline-preview {
+  border: none;
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  background: rgba(15, 32, 39, 0.08);
+  color: #245;
+  cursor: pointer;
+  transition: background 150ms ease, transform 150ms ease;
+
+  &:hover {
+    background: rgba(15, 32, 39, 0.14);
+    transform: translateY(-1px);
+  }
+}
+
 .vertical-timeline-element--no-children .vertical-timeline-element-content {
   background: 0 0;
   box-shadow: none;
@@ -457,38 +506,5 @@
     -ms-transform: translateX(0);
     -o-transform: translateX(0);
     transform: translateX(0);
-  }
-}
-
-// Some overrides
-
-.vertical-timeline-element-title {
-  font-size: 1.55em !important;
-  font-weight: 600;
-}
-
-.vertical-timeline-element-date {
-  font-size: 1.05em !important;
-}
-
-@media only screen and (max-width: 767px) {
-  .vertical-timeline {
-    width: 100%;
-  }
-
-  .vertical-timeline-element-content {
-    margin-left: 52px;
-    border-radius: 18px;
-  }
-
-  .item-content {
-    min-height: 0;
-    padding: 1.1rem;
-  }
-
-  .vertical-timeline-element-content .vertical-timeline-element-date {
-    display: block;
-    float: none;
-    margin: 0.75rem 0 0;
   }
 }

--- a/src/styles/timeline.less
+++ b/src/styles/timeline.less
@@ -163,8 +163,10 @@
   overflow: hidden;
   position: relative;
   margin-left: 60px;
-  border-radius: 0.25em;
+  border-radius: 24px;
   padding: 0;
+  background: transparent !important;
+  box-shadow: none !important;
 
   & > .item-content {
     overflow: hidden;
@@ -174,8 +176,27 @@
 }
 
 .item-content {
-  background-color: @color-bright;
-  padding: 2em;
+  min-height: 190px;
+  background: linear-gradient(180deg, rgba(248, 252, 255, 0.98), rgba(233, 243, 248, 0.96));
+  padding: 1.5rem;
+}
+
+.item-type {
+  display: inline-flex;
+  margin-bottom: 0.8rem;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(15, 32, 39, 0.08);
+  color: #456;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.timeline-copy {
+  margin-top: 0.9rem;
+  color: #405261;
 }
 
 .vertical-timeline-element--no-children .vertical-timeline-element-content {
@@ -211,11 +232,11 @@
 }
 .vertical-timeline-element-subtitle {
   font-size: 1em;
-  margin: 0;
+  margin: 0.15rem 0 0;
 }
 .vertical-timeline-element-content .vertical-timeline-element-date {
   float: left;
-  margin: 0.5em 1em;
+  margin: 0.85em 1em;
   opacity: 0.7;
 }
 .vertical-timeline-element-content::before {
@@ -226,7 +247,7 @@
   height: 0;
   width: 0;
   border: 7px solid transparent;
-  border-right: 7px solid @color-bright;
+  border-right: 7px solid rgba(248, 252, 255, 0.98);
 }
 .vertical-timeline-element--no-children .vertical-timeline-element-content::before {
   display: none;
@@ -252,7 +273,7 @@
     }
   }
   .vertical-timeline-element-content .vertical-timeline-element-date {
-    color: @color-bright;
+    color: rgba(255, 255, 255, 0.92);
     display: inline-block;
     padding: 0.5em 3em;
   }
@@ -264,7 +285,7 @@
     top: 24px;
     left: 100%;
     border-color: transparent;
-    border-left-color: @color-bright;
+    border-left-color: rgba(248, 252, 255, 0.98);
   }
   .vertical-timeline--two-columns .vertical-timeline-element-content .vertical-timeline-element-date {
     position: absolute;
@@ -292,7 +313,7 @@
     left: auto;
     right: 100%;
     border-color: transparent;
-    border-right-color: @color-bright;
+    border-right-color: rgba(248, 252, 255, 0.98);
   }
   .vertical-timeline--two-columns
     .vertical-timeline-element.vertical-timeline-element--right
@@ -442,10 +463,32 @@
 // Some overrides
 
 .vertical-timeline-element-title {
-  font-size: 1.6em !important;
-  font-weight: 500;
+  font-size: 1.55em !important;
+  font-weight: 600;
 }
 
 .vertical-timeline-element-date {
-  font-size: 1.2em !important;
+  font-size: 1.05em !important;
+}
+
+@media only screen and (max-width: 767px) {
+  .vertical-timeline {
+    width: 100%;
+  }
+
+  .vertical-timeline-element-content {
+    margin-left: 52px;
+    border-radius: 18px;
+  }
+
+  .item-content {
+    min-height: 0;
+    padding: 1.1rem;
+  }
+
+  .vertical-timeline-element-content .vertical-timeline-element-date {
+    display: block;
+    float: none;
+    margin: 0.75rem 0 0;
+  }
 }


### PR DESCRIPTION
## What changed
- redesigned the hero area into a clearer portfolio landing section with stronger contact actions and quick summary stats
- added timeline category filters so visitors can switch between work, projects, and achievements instead of scanning one long mixed feed
- refreshed timeline cards for better visual hierarchy, improved responsiveness, and clearer content labels
- updated metadata and fixed the GitHub CTA to point to the actual profile
- replaced the resize logic with a simpler responsive calculation so layout updates are more predictable

## Notes
- I couldn't generate a fresh static `docs` build in this environment because the repository's current Parcel/Babel dependency set fails under the available toolchain. The source changes are in place for review.
